### PR TITLE
Add support for CONFIG GET

### DIFF
--- a/pydis/__main__.py
+++ b/pydis/__main__.py
@@ -37,6 +37,7 @@ class RedisProtocol(asyncio.Protocol):
             b"SPOP": self.spop,
             b"LRANGE": self.lrange,
             b"MSET": self.mset,
+            b"CONFIG": self.config,
         }
 
     def connection_made(self, transport: asyncio.transports.Transport):
@@ -201,6 +202,13 @@ class RedisProtocol(asyncio.Protocol):
             value = args[i + 1]
             self.dictionary[key] = value
         return b"+OK\r\n"
+
+    def config(self, cmd, *args):
+      if cmd == b'GET':
+        key, = args
+        res = b'no' if key == b'appendonly' else b''
+        return b"*2\r\n$%d\r\n%s\r\n$%d\r\n%s\r\n" % (len(key), key, len(res), res)
+      return b"*0\r\n"
 
 
 def main() -> int:


### PR DESCRIPTION
On `redis-cli` version 6.0.6, `./benchmark.sh` produces warnings like:

```sh
$ ./benchmark.sh 
pydis 1
Could not connect to Redis at 127.0.0.1:7878: Connection refused
WARN: could not fetch server CONFIG
Could not connect to Redis at 127.0.0.1:7878: setsockopt(TCP_NODELAY): Invalid argument
pydis 2
Could not connect to Redis at 127.0.0.1:7878: Connection refused
WARN: could not fetch server CONFIG
Could not connect to Redis at 127.0.0.1:7878: setsockopt(TCP_NODELAY): Invalid argument
pydis 3
Could not connect to Redis at 127.0.0.1:7878: Connection refused
WARN: could not fetch server CONFIG
Could not connect to Redis at 127.0.0.1:7878: setsockopt(TCP_NODELAY): Invalid argument
redis 1
Could not connect to Redis at 127.0.0.1:6379: Connection refused
WARN: could not fetch server CONFIG
All clients disconnected... aborting.
```

This PR implements support for a very basic, hardcoded server config that squelches this warning.